### PR TITLE
헤더 컴포넌트 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { RouterProvider } from 'react-router-dom';
 
 import { Reset } from 'styled-reset';
 
+import '@/App.css';
 import { Router } from '@/router/Router';
 
 function App() {

--- a/src/components/common/input/index.tsx
+++ b/src/components/common/input/index.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'flex h-9 w-full rounded-xl border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+          'flex h-10 w-full rounded-lg border border-input bg-white px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
           className
         )}
         ref={ref}

--- a/src/components/feature/header/index.tsx
+++ b/src/components/feature/header/index.tsx
@@ -1,0 +1,81 @@
+import styled from 'styled-components';
+
+import {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+} from '@/components/common/avatar';
+import { Button } from '@/components/common/button';
+import { Input } from '@/components/common/input';
+
+const Header = () => {
+  return (
+    <Container>
+      <Wrapper>
+        <ChildWrapper>
+          <InputWrapper>
+            <Input type='search' placeholder='검색하세요.' />
+          </InputWrapper>
+          <BtnWrapper>
+            <Button size='sm' variant='default'>
+              검색
+            </Button>
+          </BtnWrapper>
+        </ChildWrapper>
+
+        <ChildWrapper>
+          <Avatar>
+            <AvatarImage src='https://github.com/shadcn.png' alt='@shadcn' />
+            <AvatarFallback>CN</AvatarFallback>
+          </Avatar>
+          <Name>name</Name>
+        </ChildWrapper>
+      </Wrapper>
+    </Container>
+  );
+};
+
+export default Header;
+
+const Container = styled.header`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 56px;
+`;
+
+const Wrapper = styled.div`
+  overflow: hidden;
+  width: 1440px;
+  height: 56px;
+
+  background-color: #eeeded;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 20px 8px 130px;
+  gap: 190px;
+`;
+
+const InputWrapper = styled.div`
+  width: 660px;
+`;
+
+const BtnWrapper = styled.div`
+  width: 54px;
+`;
+
+const ChildWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  max-width: 660px;
+`;
+
+const Name = styled.strong`
+  font-size: 16px;
+  color: #757575;
+`;

--- a/src/pages/RootPage.tsx
+++ b/src/pages/RootPage.tsx
@@ -1,13 +1,28 @@
-import React from 'react';
 import { Outlet } from 'react-router-dom';
+
+import styled from 'styled-components';
 
 const RootPage = () => {
   return (
-    <>
-      <div>RootPage</div>
-      <Outlet />
-    </>
+    <RootContainer>
+      <RootWrapper>
+        <Outlet />
+      </RootWrapper>
+    </RootContainer>
   );
 };
 
 export default RootPage;
+
+const RootContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+`;
+
+const RootWrapper = styled.div`
+  width: 1440px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+`;


### PR DESCRIPTION
## 🔧 작업 내용

<br>

- header 컴포넌트 구현

## 📌 참고 사항

<br>

- Root Page내 css 적용
- App.css 내 shadcn tailwind css 적용
- header (화면 내에서 1440px을 기준으로 구현할 예정이면 나머지 overflow나 화면이 줄어들시 반응형 상관없이 overflow: hidden을 적용할 예정입니다.)
<img width="1443" alt="image" src="https://github.com/user-attachments/assets/1a643831-0fc1-406b-83b7-d183662aa2bf">


## ❗️ 현재 버그

<br>

x

## ✓ Git close

resolve #19 